### PR TITLE
Add Artifacts for GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+  push:
+   paths-ignore:
+     - '.gitignore'
+     - 'CONTRIBUTING.md'
+     - 'LICENSE'
+     - 'README.md'
+     - 'licenseheader.txt'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@72f2cec99f417b1a1c5e2e88945068983b7965f9
+      - name: Change wrapper permissions
+        run: chmod +x ./gradlew
+      - uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4
+      - uses: actions/setup-java@4075bfc1b51bf22876335ae1cd589602d60d8758
+        with:
+          distribution: 'temurin'
+          java-version: 21
+      - name: Build Project
+        run: ./gradlew build
+      - name: Archive Artifacts (fabric)
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        if: success()
+        with:
+          name: BedrockSkinUtility
+          path: build/libs/BedrockSkinUtility-*.jar
+          if-no-files-found: error


### PR DESCRIPTION
Assuming you want to enable github actions first, this will create a build in github actions each time there is a commit. Used it now to build the 1.21 Minecraft Version of the BedrockSkinUtility you updated.

this build.yml is adapted from https://github.com/onebeastchris/Hurricane-Modded/blob/1.21/.github/workflows/build.yml 